### PR TITLE
Using pre-compiled RISC-V toolchain to save CI time

### DIFF
--- a/.github/setup-ci.sh
+++ b/.github/setup-ci.sh
@@ -26,7 +26,7 @@ elif [[ "$OS" == "Darwin" ]]; then
 
     # Update and install packages
     brew update
-    brew install npm icarus-verilog
+    brew install npm icarus-verilog gawk
 
 else
     echo "Unsupported OS: $OS"

--- a/.github/setup-ci.sh
+++ b/.github/setup-ci.sh
@@ -1,7 +1,39 @@
 #!/bin/bash
 
-apt-get update
-apt-get install npm autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
-apt update
-apt install iverilog
+set -e
+
+# Detect OS
+OS="$(uname)"
+echo "Detected OS: $OS"
+
+if [[ "$OS" == "Linux" ]]; then
+    # Update and install packages for Debian-based systems
+    sudo apt-get update
+    sudo apt-get install -y \
+        npm autoconf automake autotools-dev curl python3 python3-pip \
+        libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison \
+        flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev \
+        ninja-build git cmake libglib2.0-dev libslirp-dev
+
+    sudo apt install -y iverilog
+
+elif [[ "$OS" == "Darwin" ]]; then
+    # Check for Homebrew, install if missing
+    if ! command -v brew &> /dev/null; then
+        echo "Homebrew not found. Installing Homebrew..."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
+
+    # Update and install packages
+    brew update
+    brew install npm icarus-verilog
+
+else
+    echo "Unsupported OS: $OS"
+    exit 1
+fi
+
+# Install xpm globally using npm
 npm install --global xpm@latest
+
+echo "Setup complete."

--- a/.github/setup-ci.sh
+++ b/.github/setup-ci.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 apt-get update
-apt-get install autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
+apt-get install npm autoconf automake autotools-dev curl python3 python3-pip libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev ninja-build git cmake libglib2.0-dev libslirp-dev
 apt update
 apt install iverilog
+npm install --global xpm@latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,11 @@ on: push
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -12,16 +16,22 @@ jobs:
 
       - name: Set up the environment
         run: |
-          sudo ./.github/setup-ci.sh
+          ./.github/setup-ci.sh
 
       - name: Install the toolchain
         run: |
           # Install pre-compiled toolchain (for all distributions)
           xpm install @xpack-dev-tools/riscv-none-elf-gcc@14.2.0-3.1 --verbose --global
 
-      - name: Set PATH
+      - name: Set PATH (Linux)
+        if: startsWith(matrix.os, 'ubuntu-')
         run: |
           echo "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin" >> $GITHUB_PATH
+
+      - name: Set PATH (macOS)
+        if: startsWith(matrix.os, 'macos-')
+        run: |
+          echo "$HOME/Library/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin" >> $GITHUB_PATH
 
       - name: Set RISCV_PREFIX
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,13 +14,18 @@ jobs:
         run: |
           sudo ./.github/setup-ci.sh
 
-      - name: Build the toolchain
+      - name: Install the toolchain
         run: |
-          sudo ./.github/build-toolchain.sh
+          # Install pre-compiled toolchain (for all distributions)
+          xpm install @xpack-dev-tools/riscv-none-elf-gcc@14.2.0-3.1 --verbose --global
 
       - name: Set PATH
         run: |
-          echo "/opt/riscv/bin" >> "$GITHUB_PATH"
+          echo "$HOME/.local/xPacks/@xpack-dev-tools/riscv-none-elf-gcc/14.2.0-3.1/.content/bin" >> $GITHUB_PATH
+
+      - name: Set RISCV_PREFIX
+        run: |
+          echo "RISCV_PREFIX=riscv-none-elf" >> $GITHUB_ENV
 
       - name: Update submodules
         run: |

--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,13 @@ compile_tests: copy_tests
 run_vivado: compile_tests
 	for test in $(PASSING_TESTS) ; do \
 		printf "Running test %-15s\t" "$$test:"; \
-		TOHOST_ADDR=$$($(RISCV_PREFIX)-nm -n tests-build/$$test.elf | awk '$$3=="tohost" { printf "%d\n", strtonum("0x"$$1) }'); \
+		TOHOST_ADDR=$$($(RISCV_PREFIX)-nm -n tests-build/$$test.elf | gawk '$$3=="tohost" { printf "%d\n", strtonum("0x"$$1) }'); \
 		xelab cpu_tb -relax -debug all \
 			-generic_top MEM_INIT_FILE=\"tests-build/$$test.hex\" \
 			-generic_top TOHOST_ADDR=$$TOHOST_ADDR \
 			-prj v-front.prj > /dev/null; \
 		xsim cpu_tb -R --onfinish quit > tests-build/$$test.results; \
-		RESULT=$$(cat tests-build/$$test.results | awk '/Note:/ {print}' | sed 's/Note://' | awk '/Success|Failure/ {print}'); \
+		RESULT=$$(cat tests-build/$$test.results | gawk '/Note:/ {print}' | sed 's/Note://' | gawk '/Success|Failure/ {print}'); \
 		echo "$$RESULT"; \
 		if [ "$(MODE)" = "ci" ] || [ "$(MODE)" = "CI" ]; then \
 			if echo "$$RESULT" | grep -q 'Failure'; then \
@@ -82,14 +82,14 @@ run_vivado: compile_tests
 run_iverilog: compile_tests
 	for test in $(PASSING_TESTS) ; do \
 		printf "Running test %-15s\t" "$$test:"; \
-		TOHOST_ADDR=$$($(RISCV_PREFIX)-nm -n tests-build/$$test.elf | awk '$$3=="tohost" { printf "%d\n", strtonum("0x"$$1) }'); \
+		TOHOST_ADDR=$$($(RISCV_PREFIX)-nm -n tests-build/$$test.elf | gawk '$$3=="tohost" { printf "%d\n", strtonum("0x"$$1) }'); \
 		iverilog -o tests-build/$$test.out \
 			-Irtl/ -Isim/ -Irtl/luftALU/rtl/ -Irtl/luftALU/rtl/subunits/ \
 			-Pcpu_tb.MEM_INIT_FILE=\"tests-build/$$test.hex\" \
 			-Pcpu_tb.TOHOST_ADDR=$$TOHOST_ADDR \
 			sim/cpu_tb.v; \
 		vvp tests-build/$$test.out > tests-build/$$test.results; \
-		RESULT=$$(cat tests-build/$$test.results | awk '/Note:/ {print}' | sed 's/Note://' | awk '/Success|Failure/ {print}'); \
+		RESULT=$$(cat tests-build/$$test.results | gawk '/Note:/ {print}' | sed 's/Note://' | gawk '/Success|Failure/ {print}'); \
 		echo "$$RESULT"; \
 		if [ "$(MODE)" = "ci" ] || [ "$(MODE)" = "CI" ]; then \
 			if echo "$$RESULT" | grep -q 'Failure'; then \

--- a/sw/extract_hex.sh.obsolete
+++ b/sw/extract_hex.sh.obsolete
@@ -8,14 +8,14 @@ if [ -z "$1" -o -z "$2" -o -z "$3" ]; then
 	exit 1
 fi
 
-if [ -z "$TOOLCHAIN_PREFIX" ]; then
-	TOOLCHAIN_PREFIX=riscv32-unknown-elf
+if [ -z "$RISCV_PREFIX" ]; then
+	RISCV_PREFIX=riscv32-unknown-elf
 fi;
 
-$TOOLCHAIN_PREFIX-objdump -d -w $1 | sed '1,5d' | awk '!/:$/ { print $2; }' | sed '/^$/d' > $2; \
+$RISCV_PREFIX-objdump -d -w $1 | sed '1,5d' | awk '!/:$/ { print $2; }' | sed '/^$/d' > $2; \
 : > "$3"; \
-test -z "$($TOOLCHAIN_PREFIX-readelf -l $1 | grep .data)" || \
-	$TOOLCHAIN_PREFIX-objdump -s -j .data $1 | sed '1,4d' | \
+test -z "$($RISCV_PREFIX-readelf -l $1 | grep .data)" || \
+	$RISCV_PREFIX-objdump -s -j .data $1 | sed '1,4d' | \
 	awk '!/:$/ { for (i = 2; i < 6; i++) print $i; }' | sed '/^$/d' | \
 	awk 'length($0)==8 { print substr($0, 7, 2) substr($0, 5, 2) substr($0, 3, 2) substr($0, 1, 2) }' > $3;
 

--- a/sw/extract_hex.sh.obsolete
+++ b/sw/extract_hex.sh.obsolete
@@ -12,12 +12,12 @@ if [ -z "$RISCV_PREFIX" ]; then
 	RISCV_PREFIX=riscv32-unknown-elf
 fi;
 
-$RISCV_PREFIX-objdump -d -w $1 | sed '1,5d' | awk '!/:$/ { print $2; }' | sed '/^$/d' > $2; \
+$RISCV_PREFIX-objdump -d -w $1 | sed '1,5d' | gawk '!/:$/ { print $2; }' | sed '/^$/d' > $2; \
 : > "$3"; \
 test -z "$($RISCV_PREFIX-readelf -l $1 | grep .data)" || \
 	$RISCV_PREFIX-objdump -s -j .data $1 | sed '1,4d' | \
-	awk '!/:$/ { for (i = 2; i < 6; i++) print $i; }' | sed '/^$/d' | \
-	awk 'length($0)==8 { print substr($0, 7, 2) substr($0, 5, 2) substr($0, 3, 2) substr($0, 1, 2) }' > $3;
+	gawk '!/:$/ { for (i = 2; i < 6; i++) print $i; }' | sed '/^$/d' | \
+	gawk 'length($0)==8 { print substr($0, 7, 2) substr($0, 5, 2) substr($0, 3, 2) substr($0, 1, 2) }' > $3;
 
 exit 0
 

--- a/sw/test/Makefile
+++ b/sw/test/Makefile
@@ -1,4 +1,4 @@
-COMPILER_PREFIX = riscv32-unknown-elf
+COMPILER_PREFIX ?= riscv32-unknown-elf
 
 all: clean compile generate_hex
 
@@ -21,4 +21,3 @@ generate_hex: compile
 
 clean:
 	rm -rf *.o *.hex *.bin *.elf *.map ../start.o ../../sim/pmem.hex ../../sim/dmem.hex
-	


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated continuous integration scripts to install required packages and toolchains using new methods.
  - Modified workflow to use a pre-compiled RISC-V GCC toolchain via a package manager and updated environment variable handling.
  - Renamed and updated environment variables for toolchain prefixes in build scripts and Makefiles.
  - Improved compatibility by switching from `awk` to `gawk` in relevant scripts.
  - Enhanced Makefile flexibility by allowing toolchain variables to be overridden externally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->