### PR TITLE
Improve CSR unit; extend exception logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # V-FRONT Main Makefile
 # Created:		2025-05-25
-# Modified:		2026-07-10
+# Modified:		2026-07-11
 # Author:		Kagan Dikmen
 
 include ut/riscv-tests/isa/rv32ui/Makefrag
@@ -12,7 +12,8 @@ TESTS := $(rv32ui_sc_tests) $(v-front_tests)
 
 FAILING_TESTS := 
 
-EXCLUDE_TESTS := csr_permissions illegal_instr		# These tests are conducted by inspecting simulations
+# Exclude the tests that have to be conducted by inspecting simulations
+EXCLUDE_TESTS := csr_permissions illegal_instr illegal_instr_addr
 
 PASSING_TESTS := $(filter-out $(FAILING_TESTS) $(EXCLUDE_TESTS), $(TESTS))
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # V-FRONT Main Makefile
 # Created:		2025-05-25
-# Modified:		2026-07-06
+# Modified:		2026-07-10
 # Author:		Kagan Dikmen
 
 include ut/riscv-tests/isa/rv32ui/Makefrag
@@ -12,7 +12,9 @@ TESTS := $(rv32ui_sc_tests) $(v-front_tests)
 
 FAILING_TESTS := 
 
-PASSING_TESTS := $(filter-out $(FAILING_TESTS), $(TESTS))
+EXCLUDE_TESTS := csr_permissions		# csr_permissions tests are conducted by inspecting simulations
+
+PASSING_TESTS := $(filter-out $(FAILING_TESTS) $(EXCLUDE_TESTS), $(TESTS))
 
 DESIGN_SOURCES := \
 	rtl/soc/soc.v \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TESTS := $(rv32ui_sc_tests) $(v-front_tests)
 
 FAILING_TESTS := 
 
-EXCLUDE_TESTS := csr_permissions		# csr_permissions tests are conducted by inspecting simulations
+EXCLUDE_TESTS := csr_permissions illegal_instr		# These tests are conducted by inspecting simulations
 
 PASSING_TESTS := $(filter-out $(FAILING_TESTS) $(EXCLUDE_TESTS), $(TESTS))
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Find an example of how a generic C file can be compiled to run on V-FRONT by nav
 
 ## Architectural Details
 
-V-FRONT implements a five-stage pipelined von Neumann CPU architecture. In its current configuration, it has a 32 KB unified memory to store both program and data, where the first 16 KB is reserved for program memory and the second 16 KB for data memory. Misaligned accesses to the data memory are allowed, where the CPU then raises an exception and jumps to a trap vector to handle the misaligned access.
+V-FRONT implements a five-stage pipelined von Neumann CPU architecture. In its current configuration, it has a 32 KB unified memory to store both program and data, where the first 16 KB is reserved for program memory and the second 16 KB for data memory. Misaligned accesses to the data memory are detected by the CPU, which then raises an exception and jumps to a trap vector to handle the misaligned access.
 
 V-FRONT implements a CSR unit with details you can find [here](docs/csr_unit.md). As of 2026-07-11, the hardware can raise exceptions in case of:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 - RV32I v2.1 with Zicsr and Zifencei extensions
 - Five-stage von Neumann architecture
 - 32 KB unified dual-port dual-clock BRAM-based memory (16 KB program, 16 KB data)
-- CSR unit with 4096 CSR registers
-- Handles misaligned memory accesses via trap vector `mtvec_handler`
+- CSR unit
+- Handles exceptions via trap vector `mtvec_handler`
 
 ## Prerequisites
 
@@ -86,23 +86,31 @@ Find an example of how a generic C file can be compiled to run on V-FRONT by nav
 
 V-FRONT implements a five-stage pipelined von Neumann CPU architecture. In its current configuration, it has a 32 KB unified memory to store both program and data, where the first 16 KB is reserved for programs and the second 16 KB for data. Misaligned accesses to this unified BRAM memory are allowed, where the CPU then raises an exception and jumps to a trap vector to handle the misaligned access.
 
-V-FRONT implements 4096 CSR registers in its CSR unit. As of 2026-07-07, the only exception the hardware itself can raise is when a misaligned memory access is attempted. But software can raise any exception through `ecall` and `ebreak` instructions, where the program then jumps to the address stored in the CSR register `mtvec`.
+V-FRONT implements a CSR unit with details you can find [here](docs/csr_unit.md). As of 2026-07-11, the hardware can raise exceptions in case of:
+
+- a misaligned memory access,
+- an illegal instruction,
+- an illegal instruction address.
+
+Software exceptions are raised through `ecall` and `ebreak` instructions. Any exception is resolved through jumping to the trap vector you can find [here](sw/mtvec_handler.S).
 
 V-FRONT implements `fence` and `fence_i` instructions as pure `NOP`s, as these instructions do not serve any meaningful purpose in a single-core setting.
+
+Currently, V-FRONT only supports machine mode (M-mode) as privilege mode.
 
 V-FRONT is tested using the unit tests in the [ut](ut/) folder, which are sourced from [riscv-tests](https://github.com/riscv-software-src/riscv-tests). There are additional tests under [ut/v-front](ut/v-front/) as well.
 
 ## Status
 
-The unit tests all pass as of 2026-07-07. The design is fully synthesizable.
+The unit tests all pass as of 2026-07-11. The design is fully synthesizable.
 
 ### Known Issues
 
 - The five-stage pipeline is fully implemented and tested, but not optimized yet for performance. As a result, the current implementation runs at relatively low clock frequencies (below 20 MHz on Zynq 7020).
 - The control logic shoulders instruction decoding far too much. As much of it as possible should be moved to the instruction decoder module.
 - There are parametrization issues. Some parameters (like `PC_WIDTH`) do little to nothing.
-- There is only one type of exception (misaligned memory access) implemented. More should follow.
-- Documentation is limited to this README document.
+- The CSR module does not implement WARL masking yet. CSR write operations can write to any field of a register as long as the register is read-write.
+- Documentation is very limited; needs to be extended.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@
 - RV32I v2.1 with Zicsr and Zifencei extensions
 - Five-stage von Neumann architecture
 - 32 KB unified dual-port dual-clock BRAM-based memory (16 KB program, 16 KB data)
-- CSR unit
 - Handles exceptions via trap vector `mtvec_handler`
+- Unit tests for functional correctness and ISA compliance
 
 ## Prerequisites
 
@@ -84,21 +84,21 @@ Find an example of how a generic C file can be compiled to run on V-FRONT by nav
 
 ## Architectural Details
 
-V-FRONT implements a five-stage pipelined von Neumann CPU architecture. In its current configuration, it has a 32 KB unified memory to store both program and data, where the first 16 KB is reserved for programs and the second 16 KB for data. Misaligned accesses to this unified BRAM memory are allowed, where the CPU then raises an exception and jumps to a trap vector to handle the misaligned access.
+V-FRONT implements a five-stage pipelined von Neumann CPU architecture. In its current configuration, it has a 32 KB unified memory to store both program and data, where the first 16 KB is reserved for program memory and the second 16 KB for data memory. Misaligned accesses to the data memory are allowed, where the CPU then raises an exception and jumps to a trap vector to handle the misaligned access.
 
 V-FRONT implements a CSR unit with details you can find [here](docs/csr_unit.md). As of 2026-07-11, the hardware can raise exceptions in case of:
 
-- a misaligned memory access,
+- a misaligned data memory access,
 - an illegal instruction,
 - an illegal instruction address.
 
-Software exceptions are raised through `ecall` and `ebreak` instructions. Any exception is resolved through jumping to the trap vector you can find [here](sw/mtvec_handler.S).
-
-V-FRONT implements `fence` and `fence_i` instructions as pure `NOP`s, as these instructions do not serve any meaningful purpose in a single-core setting.
+Software exceptions are raised through `ecall` and `ebreak` instructions. Any exception is resolved through jumping to the trap vector you can find [here](sw/mtvec_handler.S). 
 
 Currently, V-FRONT only supports machine mode (M-mode) as privilege mode.
 
-V-FRONT is tested using the unit tests in the [ut](ut/) folder, which are sourced from [riscv-tests](https://github.com/riscv-software-src/riscv-tests). There are additional tests under [ut/v-front](ut/v-front/) as well.
+V-FRONT implements `fence` and `fence_i` instructions as pure `NOP`s, as these instructions do not serve any meaningful purpose in a single-core setting.
+
+V-FRONT is tested for functional correctness and ISA compliance using the unit tests in the [ut](ut/) folder. This directory includes tests sourced from [riscv-tests](https://github.com/riscv-software-src/riscv-tests). There are additional tests under [ut/v-front](ut/v-front/) as well. See [Getting Started](#getting-started) to learn how you can run the tests yourself.
 
 ## Status
 

--- a/docs/csr_unit.md
+++ b/docs/csr_unit.md
@@ -1,0 +1,20 @@
+# Documentation - CSR Unit
+
+CSR             | Address        | Reset Value    | Permissions
+----------------|----------------|----------------|----------------
+jvt             | 0x17           | 0x0000_0000    | RW
+mstatus         | 0x300          | 0x0000_0000    | RW
+misa            | 0x301          | 0x4000_0000    | RW
+mie             | 0x304          | 0x0000_0000    | RW
+mtvec           | 0x305          | 0x0000_0000    | RW
+mtvt            | 0x307          | 0x0000_0000    | RW
+mscratch        | 0x340          | 0x0000_0000    | RW
+mepc            | 0x341          | 0x0000_0000    | RW
+mcause          | 0x342          | 0x0000_0000    | RW
+mtval           | 0x343          | 0x0000_0000    | RW
+custom1         | 0x7F0          | 0x0000_0000    | RW
+custom2         | 0x7F1          | 0x0000_0000    | RW
+mhartid         | 0xF14          | 0x0000_0000    | RO
+
+`RW` = read & write
+`RO` = read-only

--- a/docs/csr_unit.md
+++ b/docs/csr_unit.md
@@ -1,5 +1,7 @@
 # Documentation - CSR Unit
 
+Below is a list of control and status registers V-FRONT implements in its CSR unit.
+
 CSR             | Address        | Reset Value    | Permissions
 ----------------|----------------|----------------|----------------
 jvt             | 0x17           | 0x0000_0000    | RW
@@ -18,3 +20,5 @@ mhartid         | 0xF14          | 0x0000_0000    | RO
 
 `RW` = read & write
 `RO` = read-only
+
+Currently, V-FRONT only implements machine mode (M-mode) as privilege mode. Therefore, the CSR `jvt`, although actually being a user-level CSR, is handled like a machine-level one. V-FRONT also does not implement WARL masking yet, therefore all fields of a CSR are read-write as long as the CSR itself is read-write. Accesses to non-existent CSRs raise an illegal instruction exception (mcause = 2) in the hardware.

--- a/lib/common_library.vh
+++ b/lib/common_library.vh
@@ -1,6 +1,6 @@
 // Common parameters library for the CPU
 // Created:     2024-01-20
-// Modified:    2025-05-29
+// Modified:    2026-07-10
 // Author:      Kagan Dikmen
 
 // OPCODES
@@ -126,6 +126,7 @@ localparam CSR_MSCRATCH_ADDR = 12'h340;
 localparam CSR_MEPC_ADDR    = 12'h341;
 localparam CSR_MCAUSE_ADDR  = 12'h342;
 localparam CSR_MTVAL_ADDR   = 12'h343;
+localparam CSR_MHARTID_ADDR = 12'hf14;
 localparam CSR_CUSTOM1_ADDR = 12'h7f0;
 localparam CSR_CUSTOM2_ADDR = 12'h7f1;
 
@@ -139,6 +140,7 @@ localparam CSR_MSCRATCH_RST = 32'h0000_0000;
 localparam CSR_MEPC_RST     = 32'h0000_0000;
 localparam CSR_MCAUSE_RST   = 32'h0000_0000;
 localparam CSR_MTVAL_RST    = 32'h0000_0000;
+localparam CSR_MHARTID_RST  = 32'h0000_0000;
 localparam CSR_CUSTOM1_RST  = 32'h0000_0000;
 localparam CSR_CUSTOM2_RST  = 32'h0000_0000;
 

--- a/lib/common_library.vh
+++ b/lib/common_library.vh
@@ -126,9 +126,9 @@ localparam CSR_MSCRATCH_ADDR = 12'h340;
 localparam CSR_MEPC_ADDR    = 12'h341;
 localparam CSR_MCAUSE_ADDR  = 12'h342;
 localparam CSR_MTVAL_ADDR   = 12'h343;
-localparam CSR_MHARTID_ADDR = 12'hf14;
 localparam CSR_CUSTOM1_ADDR = 12'h7f0;
 localparam CSR_CUSTOM2_ADDR = 12'h7f1;
+localparam CSR_MHARTID_ADDR = 12'hf14;
 
 localparam CSR_JVT_RST      = 32'h0000_0000;
 localparam CSR_MSTATUS_RST  = 32'h0000_1800;
@@ -140,10 +140,9 @@ localparam CSR_MSCRATCH_RST = 32'h0000_0000;
 localparam CSR_MEPC_RST     = 32'h0000_0000;
 localparam CSR_MCAUSE_RST   = 32'h0000_0000;
 localparam CSR_MTVAL_RST    = 32'h0000_0000;
-localparam CSR_MHARTID_RST  = 32'h0000_0000;
 localparam CSR_CUSTOM1_RST  = 32'h0000_0000;
 localparam CSR_CUSTOM2_RST  = 32'h0000_0000;
-
+localparam CSR_MHARTID_RST  = 32'h0000_0000;
 
 //  The following function calculates the address width based on specified RAM depth
 function integer clogb2;

--- a/lib/common_library.vh
+++ b/lib/common_library.vh
@@ -1,6 +1,6 @@
 // Common parameters library for the CPU
 // Created:     2024-01-20
-// Modified:    2026-07-10
+// Modified:    2026-07-11
 // Author:      Kagan Dikmen
 
 // OPCODES
@@ -131,7 +131,7 @@ localparam CSR_CUSTOM2_ADDR = 12'h7f1;
 localparam CSR_MHARTID_ADDR = 12'hf14;
 
 localparam CSR_JVT_RST      = 32'h0000_0000;
-localparam CSR_MSTATUS_RST  = 32'h0000_1800;
+localparam CSR_MSTATUS_RST  = 32'h0000_0000;
 localparam CSR_MISA_RST     = 32'h4000_0000;    // RV32I with no extensions
 localparam CSR_MIE_RST      = 32'h0000_0000;
 localparam CSR_MTVEC_RST    = 32'h0000_0000;

--- a/rtl/cpu/control_unit.v
+++ b/rtl/cpu/control_unit.v
@@ -1,6 +1,6 @@
 // Control unit of the CPU
 // Created:     2024-01-25
-// Modified:    2025-07-06
+// Modified:    2026-07-10
 // Author:      Kagan Dikmen
 
 module control_unit
@@ -47,7 +47,8 @@ module control_unit
 
     input branch_true,
     output make_nop,
-    output reg invalid_instr
+    output reg illegal_instr,
+    input illegal_instr_csr_ex
     );
 
     `include "common_library.vh"
@@ -162,7 +163,7 @@ module control_unit
         ldst_is_unsigned = 1'b0;
         ldst_mask = 4'b0000;
         w_en_rf_if = 1'b0;
-        invalid_instr = 1'b0;
+        illegal_instr = 1'b0;
         
         case (instr_compressed)
             {FUNCT3_ADD, R_OPCODE}: // ADD / SUB
@@ -635,13 +636,13 @@ module control_unit
                         alu_subunit_op_sel = 4'b0000;
                         w_en_rf_if = 1'b0;
                         rf_w_select = 2'b00;
-                        invalid_instr = 1'b1;
+                        illegal_instr = 1'b1;
                     end
                 endcase
             end
         endcase
 
-        if(((branch_ex && branch_true) || jump_ex || ecall_ex || ebreak_ex || mret_ex || is_misaligned) && !make_nop_ex)
+        if(((branch_ex && branch_true) || jump_ex || ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_csr_ex) && !make_nop_ex)
         begin
             make_nop_if_buffer = 1'b1;
         end

--- a/rtl/cpu/control_unit.v
+++ b/rtl/cpu/control_unit.v
@@ -1,6 +1,6 @@
 // Control unit of the CPU
 // Created:     2024-01-25
-// Modified:    2026-07-10
+// Modified:    2026-07-11
 // Author:      Kagan Dikmen
 
 module control_unit
@@ -12,6 +12,7 @@ module control_unit
 
     input [31:0] instr,
     input is_misaligned,
+    input instr_access_misaligned,
 
     // multiplexer select signals
     output reg alu_imm_select,
@@ -642,7 +643,7 @@ module control_unit
             end
         endcase
 
-        if(((branch_ex && branch_true) || jump_ex || ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_csr_ex) && !make_nop_ex)
+        if(((branch_ex && branch_true) || jump_ex || ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_csr_ex || instr_access_misaligned) && !make_nop_ex)
         begin
             make_nop_if_buffer = 1'b1;
         end

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -420,7 +420,8 @@ module cpu
             .rd_addr(rd_addr_ex),
             .illegal_instr(illegal_instr_ex && !make_nop_ex),
             .illegal_csr(illegal_csr_prel_ex),
-            .instr_access_misaligned(instr_access_misaligned && !make_nop_ex)
+            .instr_access_misaligned(instr_access_misaligned && !make_nop_ex),
+            .instr_addr(alu_result)
         );
 
     assign is_misaligned = ((ldst_mask_ex == 4'b1111 && alu_result[1:0] != 2'b00) || (ldst_mask_ex == 4'b0011 && alu_result[0] != 1'b0)) && !make_nop_ex && !cpu_stall;

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -81,7 +81,7 @@ module cpu
     reg [31:0] imm_ex;
     reg filled_ex;
     reg illegal_instr_ex;
-    wire illegal_csr_ex;
+    wire illegal_csr_prel_ex, illegal_csr_ex;
     wire instr_access_misaligned;
 
     reg bypass_alu_ready, bypass_csr_ready, bypass_ld_ready, bypass_mem_ready;
@@ -418,14 +418,15 @@ module cpu
             .misaligned_store_value(alu_opd2),
             .mem_addr(alu_result[14:0]),
             .rd_addr(rd_addr_ex),
-            .illegal_instr(illegal_instr_ex),
-            .illegal_csr(illegal_csr_ex),
-            .instr_access_misaligned(instr_access_misaligned)
+            .illegal_instr(illegal_instr_ex && !make_nop_ex),
+            .illegal_csr(illegal_csr_prel_ex),
+            .instr_access_misaligned(instr_access_misaligned && !make_nop_ex)
         );
 
     assign is_misaligned = ((ldst_mask_ex == 4'b1111 && alu_result[1:0] != 2'b00) || (ldst_mask_ex == 4'b0011 && alu_result[0] != 1'b0)) && !make_nop_ex && !cpu_stall;
     assign is_misalignment_store = is_misaligned && st_en_ex && !make_nop_ex && !cpu_stall;
-    
+    assign illegal_csr_ex = illegal_csr_prel_ex && !make_nop_ex;
+
     // 
     // STAGE 4: Memory Access (ME)
     //

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -1,6 +1,6 @@
 // Main body of the CPU
 // Created:     2024-01-26
-// Modified:    2026-07-10
+// Modified:    2026-07-11
 // Author:      Kagan Dikmen
 
 `include "luftALU/rtl/alu.v"
@@ -82,6 +82,7 @@ module cpu
     reg filled_ex;
     reg illegal_instr_ex;
     wire illegal_csr_ex;
+    wire instr_access_misaligned;
 
     reg bypass_alu_ready, bypass_csr_ready, bypass_ld_ready, bypass_mem_ready;
     reg bypass_ex_result_rs1_ex, bypass_ex_result_rs2_ex;
@@ -161,6 +162,7 @@ module cpu
             .fetch_instr(mem_if_en_o),
             .instr(mem_instr_i),
             .is_misaligned(is_misaligned),
+            .instr_access_misaligned(instr_access_misaligned),
             .alu_imm_select(ctrl_alu_imm_select_out),
             .alu_pc_select(ctrl_alu_pc_select_out),
             .rf_w_select(ctrl_rf_w_select_out),
@@ -218,7 +220,7 @@ module cpu
             .stall(cpu_stall),
             .branch(branch_ex && !make_nop_ex),
             .jump(jump_ex && !make_nop_ex),
-            .csr_sel((ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_ex || illegal_csr_ex) && !make_nop_ex),
+            .csr_sel((ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_ex || illegal_csr_ex || instr_access_misaligned) && !make_nop_ex),
             .alu_result(alu_result),
             .comp_result(comp_result),
             .csr_out(csr_unit_out),
@@ -228,6 +230,7 @@ module cpu
         );
 
     assign mem_addra_o = next_pc[14:2];
+    assign instr_access_misaligned = !make_nop_ex && ((branch_ex && comp_result) || jump_ex) && (alu_result[1] || alu_result[0]);
     
     always @(posedge sysclk)
     begin
@@ -416,7 +419,8 @@ module cpu
             .mem_addr(alu_result[14:0]),
             .rd_addr(rd_addr_ex),
             .illegal_instr(illegal_instr_ex),
-            .illegal_csr(illegal_csr_ex)
+            .illegal_csr(illegal_csr_ex),
+            .instr_access_misaligned(instr_access_misaligned)
         );
 
     assign is_misaligned = ((ldst_mask_ex == 4'b1111 && alu_result[1:0] != 2'b00) || (ldst_mask_ex == 4'b0011 && alu_result[0] != 1'b0)) && !make_nop_ex && !cpu_stall;

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -41,7 +41,7 @@ module cpu
     // IF
     wire [OP_LENGTH-1:0] pc_if, pc_plus4_if, next_pc;
     reg filled_if;
-    wire invalid_instr_if;
+    wire illegal_instr_if;
 
 
     // ID
@@ -59,7 +59,7 @@ module cpu
     wire bypass_me_result_rs1_id, bypass_me_result_rs2_id;
     wire [31:0] imm_id;
     reg filled_id;
-    reg invalid_instr_id;
+    reg illegal_instr_id;
 
 
     // EX
@@ -80,7 +80,7 @@ module cpu
     reg [31:0] instr_ex;
     reg [31:0] imm_ex;
     reg filled_ex;
-    reg invalid_instr_ex;
+    reg illegal_instr_ex;
     wire illegal_csr_ex;
 
     reg bypass_alu_ready, bypass_csr_ready, bypass_ld_ready, bypass_mem_ready;
@@ -117,7 +117,7 @@ module cpu
     reg ready_for_mem_acc;
     wire cpu_stall;
     reg filled_me;
-    reg invalid_instr_me;
+    reg illegal_instr_me;
     
 
     // WB
@@ -130,7 +130,7 @@ module cpu
     reg [4:0] rd_addr_wb;
     reg [OP_LENGTH-1:0] pc_plus4_wb;
     reg filled_wb;
-    reg invalid_instr_wb;
+    reg illegal_instr_wb;
     
 
     //
@@ -183,13 +183,14 @@ module cpu
             .csr_imm_select(csr_imm_select),
             .branch_true(comp_result[0]),
             .make_nop(make_nop_ex),
-            .invalid_instr(invalid_instr_if)
+            .illegal_instr(illegal_instr_if),
+            .illegal_instr_csr_ex(illegal_instr_ex || illegal_csr_ex)
         );
 
     always @(posedge sysclk)
     begin
         if(!cpu_stall) begin
-            instr_id <= invalid_instr_if ? 32'h00000013 : mem_instr_i;
+            instr_id <= illegal_instr_if ? 32'h00000013 : mem_instr_i;
             alu_imm_select_id <= ctrl_alu_imm_select_out;
             alu_pc_select_id <= ctrl_alu_pc_select_out;
             rf_w_select_id <= ctrl_rf_w_select_out;
@@ -205,7 +206,7 @@ module cpu
             ldst_mask_id <= ctrl_ldst_mask_out;
             ldst_is_unsigned_id <= ctrl_ldst_is_unsigned_out;
             st_en_id <= ctrl_st_en_if_out;
-            invalid_instr_id <= invalid_instr_if;
+            illegal_instr_id <= illegal_instr_if;
         end
     end
 
@@ -217,7 +218,7 @@ module cpu
             .stall(cpu_stall),
             .branch(branch_ex && !make_nop_ex),
             .jump(jump_ex && !make_nop_ex),
-            .csr_sel((ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_ex) && !make_nop_ex),
+            .csr_sel((ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_ex || illegal_csr_ex) && !make_nop_ex),
             .alu_result(alu_result),
             .comp_result(comp_result),
             .csr_out(csr_unit_out),
@@ -295,7 +296,7 @@ module cpu
             ldst_is_unsigned_ex <= ldst_is_unsigned_id;
             st_en_ex <= st_en_id;
             rd_addr_ex <= rd_addr_id;
-            invalid_instr_ex <= invalid_instr_id;
+            illegal_instr_ex <= illegal_instr_id;
             bypass_ex_result_rs1_ex <= bypass_ex_result_rs1_id;
             bypass_ex_result_rs2_ex <= bypass_ex_result_rs2_id;
             bypass_me_result_rs1_ex <= bypass_me_result_rs1_id;
@@ -341,7 +342,7 @@ module cpu
         bypass_csr_ready <= 1'b0;
         bypass_ld_ready <= 1'b0;
         
-        if(w_en_rf_ex && !is_misaligned && !illegal_instr_ex && !make_nop_ex && !cpu_stall)
+        if(w_en_rf_ex && !is_misaligned && !illegal_instr_ex && !illegal_csr_ex && !make_nop_ex && !cpu_stall)
         begin
             if(rf_w_select_ex == 2'b00)
                 bypass_alu_ready <= 1'b1;
@@ -414,12 +415,12 @@ module cpu
             .misaligned_store_value(alu_opd2),
             .mem_addr(alu_result[14:0]),
             .rd_addr(rd_addr_ex),
+            .illegal_instr(illegal_instr_ex),
             .illegal_csr(illegal_csr_ex)
         );
 
     assign is_misaligned = ((ldst_mask_ex == 4'b1111 && alu_result[1:0] != 2'b00) || (ldst_mask_ex == 4'b0011 && alu_result[0] != 1'b0)) && !make_nop_ex && !cpu_stall;
     assign is_misalignment_store = is_misaligned && st_en_ex && !make_nop_ex && !cpu_stall;
-    assign illegal_instr_ex = illegal_csr_ex || invalid_instr_ex;
     
     // 
     // STAGE 4: Memory Access (ME)
@@ -442,7 +443,7 @@ module cpu
             w_en_rf_me <= w_en_rf_ex;
             instr_me <= instr_ex;
             pc_me <= pc_ex;
-            invalid_instr_me <= invalid_instr_ex;
+            illegal_instr_me <= illegal_instr_ex;
         end
     end
 
@@ -504,7 +505,7 @@ module cpu
             w_en_rf_wb <= w_en_rf_me;
             make_nop_wb <= make_nop_me;
             rd_addr_wb <= rd_addr_me;
-            invalid_instr_wb <= invalid_instr_me;
+            illegal_instr_wb <= illegal_instr_me;
         end
     end
 
@@ -524,7 +525,7 @@ module cpu
         (
             .clk(sysclk),
             .rst(rst),
-            .w_en(w_en_rf_wb && !make_nop_wb && (!cpu_stall || (cpu_stall && ready_for_mem_acc)) && !invalid_instr_wb),
+            .w_en(w_en_rf_wb && !make_nop_wb && (!cpu_stall || (cpu_stall && ready_for_mem_acc)) && !illegal_instr_wb),
             .rs1_addr(rs1_addr_ex),
             .rs2_addr(rs2_addr_ex),
             .rd_addr(rd_addr_wb),

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -342,7 +342,7 @@ module cpu
         bypass_csr_ready <= 1'b0;
         bypass_ld_ready <= 1'b0;
         
-        if(w_en_rf_ex && !is_misaligned && !illegal_instr_ex && !illegal_csr_ex && !make_nop_ex && !cpu_stall)
+        if(w_en_rf_ex && !make_nop_ex && !cpu_stall)
         begin
             if(rf_w_select_ex == 2'b00)
                 bypass_alu_ready <= 1'b1;

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -1,6 +1,6 @@
 // Main body of the CPU
 // Created:     2024-01-26
-// Modified:    2026-07-07
+// Modified:    2026-07-10
 // Author:      Kagan Dikmen
 
 `include "luftALU/rtl/alu.v"
@@ -394,7 +394,7 @@ module cpu
             .z(csr_in)
         );
     
-    csr_unit #(.CSR_REG_COUNT(4096)) csr_unit_cpu
+    csr_unit #(.CSR_ADDR_WIDTH(12)) csr_unit_cpu
         (
             .clk(sysclk),
             .rst(rst),
@@ -412,7 +412,8 @@ module cpu
             .is_misalignment_store(is_misalignment_store),
             .misaligned_store_value(alu_opd2),
             .mem_addr(alu_result[14:0]),
-            .rd_addr(rd_addr_ex)
+            .rd_addr(rd_addr_ex),
+            .illegal_csr()
         );
 
     assign is_misaligned = ((ldst_mask_ex == 4'b1111 && alu_result[1:0] != 2'b00) || (ldst_mask_ex == 4'b0011 && alu_result[0] != 1'b0)) && !make_nop_ex && !cpu_stall;

--- a/rtl/cpu/cpu.v
+++ b/rtl/cpu/cpu.v
@@ -81,6 +81,7 @@ module cpu
     reg [31:0] imm_ex;
     reg filled_ex;
     reg invalid_instr_ex;
+    wire illegal_csr_ex;
 
     reg bypass_alu_ready, bypass_csr_ready, bypass_ld_ready, bypass_mem_ready;
     reg bypass_ex_result_rs1_ex, bypass_ex_result_rs2_ex;
@@ -216,7 +217,7 @@ module cpu
             .stall(cpu_stall),
             .branch(branch_ex && !make_nop_ex),
             .jump(jump_ex && !make_nop_ex),
-            .csr_sel((ecall_ex || ebreak_ex || mret_ex || is_misaligned) && !make_nop_ex),
+            .csr_sel((ecall_ex || ebreak_ex || mret_ex || is_misaligned || illegal_instr_ex) && !make_nop_ex),
             .alu_result(alu_result),
             .comp_result(comp_result),
             .csr_out(csr_unit_out),
@@ -340,7 +341,7 @@ module cpu
         bypass_csr_ready <= 1'b0;
         bypass_ld_ready <= 1'b0;
         
-        if(w_en_rf_ex && !is_misaligned && !make_nop_ex && !cpu_stall)
+        if(w_en_rf_ex && !is_misaligned && !illegal_instr_ex && !make_nop_ex && !cpu_stall)
         begin
             if(rf_w_select_ex == 2'b00)
                 bypass_alu_ready <= 1'b1;
@@ -413,11 +414,12 @@ module cpu
             .misaligned_store_value(alu_opd2),
             .mem_addr(alu_result[14:0]),
             .rd_addr(rd_addr_ex),
-            .illegal_csr()
+            .illegal_csr(illegal_csr_ex)
         );
 
     assign is_misaligned = ((ldst_mask_ex == 4'b1111 && alu_result[1:0] != 2'b00) || (ldst_mask_ex == 4'b0011 && alu_result[0] != 1'b0)) && !make_nop_ex && !cpu_stall;
     assign is_misalignment_store = is_misaligned && st_en_ex && !make_nop_ex && !cpu_stall;
+    assign illegal_instr_ex = illegal_csr_ex || invalid_instr_ex;
     
     // 
     // STAGE 4: Memory Access (ME)

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -83,12 +83,12 @@ module csr_unit
         else if (ecall || ebreak)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
-            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (ecall) ? 32'd11 : 32'd3;
+            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (ecall) ? 32'd8 : 32'd3;
         end
         else if (is_misaligned)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
-            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (is_misalignment_store) ? 32'd4 : 32'd6;
+            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (is_misalignment_store) ? 32'd6 : 32'd4;
             spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX] <= in;     // saves the instruction word
             spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]  <= {17'b0, mem_addr};
             spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]  <= (is_misalignment_store) ? misaligned_store_value : {27'b0, rd_addr};
@@ -96,7 +96,7 @@ module csr_unit
         else if (illegal_csr)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
-            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd3;   // illegal instruction causes ebreak
+            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd2;
         end
         else if (spec_reg_w_en)
         begin

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -34,14 +34,15 @@ module csr_unit
     input illegal_instr,
     output illegal_csr,
 
-    input instr_access_misaligned
+    input instr_access_misaligned,
+    input [31:0] instr_addr
     );
 
     `include "common_library.vh"
 
     reg spec_reg_r_en, spec_reg_w_en;
     reg [31:0] write_value;
-    reg [31:0] spec_csr_registers [11:0];
+    reg [31:0] spec_csr_registers [12:0];
 
     reg [1:0] current_priv;
 
@@ -57,9 +58,10 @@ module csr_unit
     localparam SPEC_CSR_MSCRATCH_INDEX  = 6;
     localparam SPEC_CSR_MEPC_INDEX      = 7;
     localparam SPEC_CSR_MCAUSE_INDEX    = 8;
-    localparam SPEC_CSR_CUSTOM1_INDEX   = 9;
-    localparam SPEC_CSR_CUSTOM2_INDEX   = 10;
-    localparam SPEC_CSR_MHARTID_INDEX   = 11;
+    localparam SPEC_CSR_MTVAL_INDEX     = 9;
+    localparam SPEC_CSR_CUSTOM1_INDEX   = 10;
+    localparam SPEC_CSR_CUSTOM2_INDEX   = 11;
+    localparam SPEC_CSR_MHARTID_INDEX   = 12;
 
     // write
     always @(posedge clk)
@@ -77,6 +79,7 @@ module csr_unit
             spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX]     <= CSR_MSCRATCH_RST;
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]         <= CSR_MEPC_RST;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]       <= CSR_MCAUSE_RST;
+            spec_csr_registers[SPEC_CSR_MTVAL_INDEX]        <= CSR_MTVAL_RST;
             spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]      <= CSR_CUSTOM1_RST;
             spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]      <= CSR_CUSTOM2_RST;
             spec_csr_registers[SPEC_CSR_MHARTID_INDEX]      <= CSR_MHARTID_RST;
@@ -92,6 +95,7 @@ module csr_unit
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (ecall) ? 32'd11 : 32'd3;
+            spec_csr_registers[SPEC_CSR_MTVAL_INDEX]    <= 'b0;
 
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
@@ -103,8 +107,8 @@ module csr_unit
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (is_misalignment_store) ? 32'd6 : 32'd4;
             spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX] <= in;     // saves the instruction word
-            spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]  <= {17'b0, mem_addr};
-            spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]  <= (is_misalignment_store) ? misaligned_store_value : {27'b0, rd_addr};
+            spec_csr_registers[SPEC_CSR_MTVAL_INDEX]    <= {17'b0, mem_addr};
+            spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]  <= (is_misalignment_store) ? misaligned_store_value : {27'b0, rd_addr};
 
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
@@ -125,6 +129,7 @@ module csr_unit
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd0;
+            spec_csr_registers[SPEC_CSR_MTVAL_INDEX]    <= instr_addr;
 
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
@@ -143,6 +148,7 @@ module csr_unit
                 CSR_MSCRATCH_ADDR:     spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX]  <= write_value;
                 CSR_MEPC_ADDR:         spec_csr_registers[SPEC_CSR_MEPC_INDEX]      <= write_value;
                 CSR_MCAUSE_ADDR:       spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]    <= write_value;
+                CSR_MTVAL_ADDR:        spec_csr_registers[SPEC_CSR_MTVAL_INDEX]     <= write_value;
                 CSR_CUSTOM1_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]   <= write_value;
                 CSR_CUSTOM2_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]   <= write_value;
             endcase
@@ -165,6 +171,7 @@ module csr_unit
             || csr_addr == CSR_MSCRATCH_ADDR
             || csr_addr == CSR_MEPC_ADDR
             || csr_addr == CSR_MCAUSE_ADDR
+            || csr_addr == CSR_MTVAL_ADDR
             || csr_addr == CSR_CUSTOM1_ADDR
             || csr_addr == CSR_CUSTOM2_ADDR)
         begin
@@ -198,6 +205,7 @@ module csr_unit
                 CSR_MSCRATCH_ADDR:     out <= spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX];
                 CSR_MEPC_ADDR:         out <= spec_csr_registers[SPEC_CSR_MEPC_INDEX];
                 CSR_MCAUSE_ADDR:       out <= spec_csr_registers[SPEC_CSR_MCAUSE_INDEX];
+                CSR_MTVAL_ADDR:        out <= spec_csr_registers[SPEC_CSR_MTVAL_INDEX];
                 CSR_CUSTOM1_ADDR:      out <= spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX];
                 CSR_CUSTOM2_ADDR:      out <= spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX];
                 CSR_MHARTID_ADDR:      out <= spec_csr_registers[SPEC_CSR_MHARTID_INDEX];

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -92,6 +92,11 @@ module csr_unit
             spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]  <= {17'b0, mem_addr};
             spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]  <= (is_misalignment_store) ? misaligned_store_value : {27'b0, rd_addr};
         end
+        else if (illegal_csr)
+        begin
+            spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
+            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd3;   // illegal instruction causes ebreak
+        end
         else if (spec_reg_w_en)
         begin
             case(csr_addr)
@@ -141,7 +146,9 @@ module csr_unit
 
     always @(negedge clk)
     begin
-        if(r_en)
+        out <= 'b0;
+
+        if(spec_reg_r_en)
         begin
             case(csr_addr)
                 CSR_JVT_ADDR:          out <= spec_csr_registers[SPEC_CSR_JVT_INDEX];
@@ -156,7 +163,12 @@ module csr_unit
                 CSR_CUSTOM1_ADDR:      out <= spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX];
                 CSR_CUSTOM2_ADDR:      out <= spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX];
                 CSR_MHARTID_ADDR:      out <= spec_csr_registers[SPEC_CSR_MHARTID_INDEX];
+                default:               out <= 'b0;
             endcase
+        end
+
+        if(illegal_csr) begin
+            out <= spec_csr_registers[SPEC_CSR_MTVEC_INDEX];
         end
     end
 

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -31,6 +31,7 @@ module csr_unit
     input [14:0] mem_addr,
     input [4:0] rd_addr,
 
+    input illegal_instr,
     output illegal_csr
     );
 
@@ -93,7 +94,7 @@ module csr_unit
             spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]  <= {17'b0, mem_addr};
             spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]  <= (is_misalignment_store) ? misaligned_store_value : {27'b0, rd_addr};
         end
-        else if (illegal_csr)
+        else if (illegal_instr || illegal_csr)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd2;
@@ -172,7 +173,7 @@ module csr_unit
             endcase
         end
 
-        if(illegal_csr) begin
+        if(illegal_instr || illegal_csr) begin
             out <= spec_csr_registers[SPEC_CSR_MTVEC_INDEX];
         end
     end

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -1,11 +1,11 @@
 // CSR unit
 // Created:     2025-05-25
-// Modified:    2026-07-05
+// Modified:    2026-07-10
 // Author:      Kagan Dikmen
 
 module csr_unit
     #(
-    parameter CSR_REG_COUNT = 4096
+    parameter CSR_ADDR_WIDTH = 12
     )(
     input clk,
     input rst,
@@ -21,7 +21,7 @@ module csr_unit
 
     input [2:0] op,
     input [31:0] in,
-    input [clogb2(CSR_REG_COUNT-1)-1:0] csr_addr,
+    input [CSR_ADDR_WIDTH-1:0] csr_addr,
 
     output reg [31:0] out,
 
@@ -29,39 +29,18 @@ module csr_unit
     input is_misalignment_store,
     input [31:0] misaligned_store_value,
     input [14:0] mem_addr,
-    input [4:0] rd_addr
+    input [4:0] rd_addr,
+
+    output illegal_csr
     );
 
     `include "common_library.vh"
 
-    wire [11:0] csr_bram_rd_addr, csr_bram_wr_addr;
-    reg [31:0] csr_bram_ram_in;
-    wire [31:0] csr_bram_r_out;
-    reg [3:0] csr_bram_w_en;
     reg spec_reg_r_en, spec_reg_w_en;
+    reg [31:0] write_value;
+    reg [31:0] spec_csr_registers [11:0];
 
-    // a for reads, b for writes
-    bram_dual #(.RAM_DEPTH(4096)) csr_registers
-    (
-        .addra(csr_bram_rd_addr),
-        .addrb(csr_bram_wr_addr),
-        .dina(),
-        .dinb(csr_bram_ram_in),
-        .clka(clk),
-        .clkb(clk),
-        .wea(4'b0000),
-        .web(csr_bram_w_en),
-        .ena(1'b1),
-        .enb(1'b1),
-        .rsta(),
-        .rstb(),
-        .regcea(),
-        .regceb(),
-        .douta(csr_bram_r_out),
-        .doutb()
-    );
-
-    reg [31:0] spec_csr_registers [10:0];
+    reg not_csr;
 
     localparam SPEC_CSR_JVT_INDEX       = 0;
     localparam SPEC_CSR_MSTATUS_INDEX   = 1;
@@ -74,6 +53,7 @@ module csr_unit
     localparam SPEC_CSR_MCAUSE_INDEX    = 8;
     localparam SPEC_CSR_CUSTOM1_INDEX   = 9;
     localparam SPEC_CSR_CUSTOM2_INDEX   = 10;
+    localparam SPEC_CSR_MHARTID_INDEX   = 11;
 
     // write
     always @(posedge clk)
@@ -91,6 +71,7 @@ module csr_unit
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]       <= CSR_MCAUSE_RST;
             spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]      <= CSR_CUSTOM1_RST;
             spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]      <= CSR_CUSTOM2_RST;
+            spec_csr_registers[SPEC_CSR_MHARTID_INDEX]      <= CSR_MHARTID_RST;
         end
         else if (mret == 1'b1)
         begin
@@ -114,30 +95,27 @@ module csr_unit
         else if (spec_reg_w_en)
         begin
             case(csr_addr)
-                CSR_JVT_ADDR:          spec_csr_registers[SPEC_CSR_JVT_INDEX]       <= csr_bram_ram_in;
-                CSR_MSTATUS_ADDR:      spec_csr_registers[SPEC_CSR_MSTATUS_INDEX]   <= csr_bram_ram_in;
-                CSR_MISA_ADDR:         spec_csr_registers[SPEC_CSR_MISA_INDEX]      <= csr_bram_ram_in;
-                CSR_MIE_ADDR:          spec_csr_registers[SPEC_CSR_MIE_INDEX]       <= csr_bram_ram_in;
-                CSR_MTVEC_ADDR:        spec_csr_registers[SPEC_CSR_MTVEC_INDEX]     <= csr_bram_ram_in;
-                CSR_MTVT_ADDR:         spec_csr_registers[SPEC_CSR_MTVT_INDEX]      <= csr_bram_ram_in;
-                CSR_MSCRATCH_ADDR:     spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX]  <= csr_bram_ram_in;
-                CSR_MEPC_ADDR:         spec_csr_registers[SPEC_CSR_MEPC_INDEX]      <= csr_bram_ram_in;
-                CSR_MCAUSE_ADDR:       spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]    <= csr_bram_ram_in;
-                CSR_CUSTOM1_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]   <= csr_bram_ram_in;
-                CSR_CUSTOM2_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]   <= csr_bram_ram_in;
+                CSR_JVT_ADDR:          spec_csr_registers[SPEC_CSR_JVT_INDEX]       <= write_value;
+                CSR_MSTATUS_ADDR:      spec_csr_registers[SPEC_CSR_MSTATUS_INDEX]   <= write_value;
+                CSR_MISA_ADDR:         spec_csr_registers[SPEC_CSR_MISA_INDEX]      <= write_value;
+                CSR_MIE_ADDR:          spec_csr_registers[SPEC_CSR_MIE_INDEX]       <= write_value;
+                CSR_MTVEC_ADDR:        spec_csr_registers[SPEC_CSR_MTVEC_INDEX]     <= write_value;
+                CSR_MTVT_ADDR:         spec_csr_registers[SPEC_CSR_MTVT_INDEX]      <= write_value;
+                CSR_MSCRATCH_ADDR:     spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX]  <= write_value;
+                CSR_MEPC_ADDR:         spec_csr_registers[SPEC_CSR_MEPC_INDEX]      <= write_value;
+                CSR_MCAUSE_ADDR:       spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]    <= write_value;
+                CSR_CUSTOM1_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]   <= write_value;
+                CSR_CUSTOM2_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]   <= write_value;
+                CSR_MHARTID_ADDR:      spec_csr_registers[SPEC_CSR_MHARTID_INDEX]   <= write_value;
             endcase
         end
     end
 
-    assign csr_bram_wr_addr = csr_addr;
-    assign csr_bram_rd_addr = csr_addr;
-
     always @(*)
     begin
-        
-        csr_bram_w_en <= 4'b0000;
-        spec_reg_r_en <= 1'b0;
-        spec_reg_w_en <= 1'b0;
+        spec_reg_r_en = 1'b0;
+        spec_reg_w_en = 1'b0;
+        not_csr = 1'b0;
         
         if(csr_addr == CSR_JVT_ADDR 
             || csr_addr == CSR_MSTATUS_ADDR
@@ -149,23 +127,21 @@ module csr_unit
             || csr_addr == CSR_MEPC_ADDR
             || csr_addr == CSR_MCAUSE_ADDR
             || csr_addr == CSR_CUSTOM1_ADDR
-            || csr_addr == CSR_CUSTOM2_ADDR)
+            || csr_addr == CSR_CUSTOM2_ADDR
+            || csr_addr == CSR_MHARTID_ADDR)
         begin
-            if(r_en == 1'b1)
-                spec_reg_r_en <= 1'b1;
-            else if(w_en == 1'b1)
-                spec_reg_w_en <= 1'b1;
+            spec_reg_r_en = r_en;
+            spec_reg_w_en = w_en;
         end
         else
-            csr_bram_w_en <= {4{w_en}};
+        begin
+            not_csr = 1'b1;
+        end
     end
 
     always @(negedge clk)
     begin
-
-        out <= csr_bram_r_out;
-
-        if(r_en == 1'b1 && spec_reg_r_en)
+        if(r_en)
         begin
             case(csr_addr)
                 CSR_JVT_ADDR:          out <= spec_csr_registers[SPEC_CSR_JVT_INDEX];
@@ -179,23 +155,26 @@ module csr_unit
                 CSR_MCAUSE_ADDR:       out <= spec_csr_registers[SPEC_CSR_MCAUSE_INDEX];
                 CSR_CUSTOM1_ADDR:      out <= spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX];
                 CSR_CUSTOM2_ADDR:      out <= spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX];
+                CSR_MHARTID_ADDR:      out <= spec_csr_registers[SPEC_CSR_MHARTID_INDEX];
             endcase
         end
     end
 
-    // read
+    // write masking
     always @(*)
     begin
         casez (op)
             3'b?01:
-                csr_bram_ram_in = in;
+                write_value = in;
             3'b?10:
-                csr_bram_ram_in = (out | in);
+                write_value = (out | in);
             3'b?11:
-                csr_bram_ram_in = (out & (~in));
+                write_value = (out & (~in));
             default:
-                csr_bram_ram_in = in;
+                write_value = in;
         endcase
     end
+
+    assign illegal_csr = not_csr && (r_en || w_en);
 
 endmodule

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -41,6 +41,7 @@ module csr_unit
     reg [31:0] spec_csr_registers [11:0];
 
     reg not_csr;
+    reg write_to_ro_csr;
 
     localparam SPEC_CSR_JVT_INDEX       = 0;
     localparam SPEC_CSR_MSTATUS_INDEX   = 1;
@@ -111,7 +112,6 @@ module csr_unit
                 CSR_MCAUSE_ADDR:       spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]    <= write_value;
                 CSR_CUSTOM1_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]   <= write_value;
                 CSR_CUSTOM2_ADDR:      spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]   <= write_value;
-                CSR_MHARTID_ADDR:      spec_csr_registers[SPEC_CSR_MHARTID_INDEX]   <= write_value;
             endcase
         end
     end
@@ -121,6 +121,7 @@ module csr_unit
         spec_reg_r_en = 1'b0;
         spec_reg_w_en = 1'b0;
         not_csr = 1'b0;
+        write_to_ro_csr = 1'b0;
         
         if(csr_addr == CSR_JVT_ADDR 
             || csr_addr == CSR_MSTATUS_ADDR
@@ -132,11 +133,15 @@ module csr_unit
             || csr_addr == CSR_MEPC_ADDR
             || csr_addr == CSR_MCAUSE_ADDR
             || csr_addr == CSR_CUSTOM1_ADDR
-            || csr_addr == CSR_CUSTOM2_ADDR
-            || csr_addr == CSR_MHARTID_ADDR)
+            || csr_addr == CSR_CUSTOM2_ADDR)
         begin
             spec_reg_r_en = r_en;
             spec_reg_w_en = w_en;
+        end
+        else if(csr_addr == CSR_MHARTID_ADDR)
+        begin
+            spec_reg_r_en = r_en;
+            write_to_ro_csr = w_en;
         end
         else
         begin
@@ -187,6 +192,6 @@ module csr_unit
         endcase
     end
 
-    assign illegal_csr = not_csr && (r_en || w_en);
+    assign illegal_csr = ((r_en || w_en) && not_csr) || write_to_ro_csr;
 
 endmodule

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -43,6 +43,8 @@ module csr_unit
     reg [31:0] write_value;
     reg [31:0] spec_csr_registers [11:0];
 
+    reg [1:0] current_priv;
+
     reg not_csr;
     reg write_to_ro_csr;
 
@@ -64,6 +66,8 @@ module csr_unit
     begin
         if (rst == 1'b1)
         begin
+            current_priv <= 2'b11;  // boot the chip in M mode
+
             spec_csr_registers[SPEC_CSR_JVT_INDEX]          <= CSR_JVT_RST;
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX]      <= CSR_MSTATUS_RST;
             spec_csr_registers[SPEC_CSR_MISA_INDEX]         <= CSR_MISA_RST;
@@ -81,12 +85,18 @@ module csr_unit
         begin
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7];
             spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= 1'b1;
-            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11] <= 2'b00;
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11] <= 2'b11;     // set back to least-privileged mode supported (M)
+            current_priv <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11];
         end
         else if (ecall || ebreak)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (ecall) ? 32'd11 : 32'd3;
+
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11] <= current_priv;
+            current_priv <= 2'b11;
         end
         else if (is_misaligned)
         begin
@@ -95,16 +105,31 @@ module csr_unit
             spec_csr_registers[SPEC_CSR_MSCRATCH_INDEX] <= in;     // saves the instruction word
             spec_csr_registers[SPEC_CSR_CUSTOM1_INDEX]  <= {17'b0, mem_addr};
             spec_csr_registers[SPEC_CSR_CUSTOM2_INDEX]  <= (is_misalignment_store) ? misaligned_store_value : {27'b0, rd_addr};
+
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11] <= current_priv;
+            current_priv <= 2'b11;
         end
         else if (illegal_instr || illegal_csr)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd2;
+
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11] <= current_priv;
+            current_priv <= 2'b11;
         end
         else if (instr_access_misaligned)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd0;
+
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][7] <= spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1];
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][1] <= 1'b0;
+            spec_csr_registers[SPEC_CSR_MSTATUS_INDEX][12:11] <= current_priv;
+            current_priv <= 2'b11;
         end
         else if (spec_reg_w_en)
         begin

--- a/rtl/cpu/csr_unit.v
+++ b/rtl/cpu/csr_unit.v
@@ -1,6 +1,6 @@
 // CSR unit
 // Created:     2025-05-25
-// Modified:    2026-07-10
+// Modified:    2026-07-11
 // Author:      Kagan Dikmen
 
 module csr_unit
@@ -32,7 +32,9 @@ module csr_unit
     input [4:0] rd_addr,
 
     input illegal_instr,
-    output illegal_csr
+    output illegal_csr,
+
+    input instr_access_misaligned
     );
 
     `include "common_library.vh"
@@ -84,7 +86,7 @@ module csr_unit
         else if (ecall || ebreak)
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
-            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (ecall) ? 32'd8 : 32'd3;
+            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= (ecall) ? 32'd11 : 32'd3;
         end
         else if (is_misaligned)
         begin
@@ -98,6 +100,11 @@ module csr_unit
         begin
             spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
             spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd2;
+        end
+        else if (instr_access_misaligned)
+        begin
+            spec_csr_registers[SPEC_CSR_MEPC_INDEX]     <= pc;
+            spec_csr_registers[SPEC_CSR_MCAUSE_INDEX]   <= 32'd0;
         end
         else if (spec_reg_w_en)
         begin
@@ -173,7 +180,7 @@ module csr_unit
             endcase
         end
 
-        if(illegal_instr || illegal_csr) begin
+        if(illegal_instr || illegal_csr || instr_access_misaligned) begin
             out <= spec_csr_registers[SPEC_CSR_MTVEC_INDEX];
         end
     end

--- a/sw/mtvec_handler.S
+++ b/sw/mtvec_handler.S
@@ -1,6 +1,6 @@
 # Trap vector mtvec_handler to manage misaligned loads and stores
 # Created:      2025-05-28
-# Modified:     2025-06-02
+# Modified:     2026-07-10
 # Author:       Kagan Dikmen
 
 .section .text.mtvec
@@ -15,12 +15,22 @@
 mtvec_handler:
     jal ra, gpr_save
     csrr t5, mcause
+    li t6, 0x3
+    beq t5, t6, handle_ebreak
+    li t6, 0xB
+    beq t5, t6, handle_ecall
     li t6, 0x6
     beq t5, t6, load_misaligned
     csrr t5, mcause
     li t6, 0x4
     beq t5, t6, store_misaligned
     j finalize
+
+handle_ebreak:
+1:  j 1b
+
+handle_ecall:
+1:  j 1b
 
 load_misaligned:
     csrr t5, mscratch

--- a/sw/mtvec_handler.S
+++ b/sw/mtvec_handler.S
@@ -15,16 +15,20 @@
 mtvec_handler:
     jal ra, gpr_save
     csrr t5, mcause
+    li t6, 0x2
+    beq t5, t6, illegal_instr
     li t6, 0x3
     beq t5, t6, handle_ebreak
-    li t6, 0xB
-    beq t5, t6, handle_ecall
-    li t6, 0x6
-    beq t5, t6, load_misaligned
-    csrr t5, mcause
     li t6, 0x4
+    beq t5, t6, load_misaligned
+    li t6, 0x6
     beq t5, t6, store_misaligned
+    li t6, 0x8
+    beq t5, t6, handle_ecall
     j finalize
+
+illegal_instr:
+1:  j 1b
 
 handle_ebreak:
 1:  j 1b

--- a/sw/mtvec_handler.S
+++ b/sw/mtvec_handler.S
@@ -1,6 +1,6 @@
 # Trap vector mtvec_handler to manage misaligned loads and stores
 # Created:      2025-05-28
-# Modified:     2026-07-10
+# Modified:     2026-07-11
 # Author:       Kagan Dikmen
 
 .section .text.mtvec
@@ -15,17 +15,22 @@
 mtvec_handler:
     jal ra, gpr_save
     csrr t5, mcause
-    li t6, 0x2
+    li t6, 0
+    beq t5, t6, instr_addr_misaligned
+    li t6, 2
     beq t5, t6, illegal_instr
-    li t6, 0x3
+    li t6, 3
     beq t5, t6, handle_ebreak
-    li t6, 0x4
+    li t6, 4
     beq t5, t6, load_misaligned
-    li t6, 0x6
+    li t6, 6
     beq t5, t6, store_misaligned
-    li t6, 0x8
+    li t6, 11
     beq t5, t6, handle_ecall
     j finalize
+
+instr_addr_misaligned:
+1:  j 1b
 
 illegal_instr:
 1:  j 1b

--- a/sw/mtvec_handler.S
+++ b/sw/mtvec_handler.S
@@ -5,10 +5,10 @@
 
 .section .text.mtvec
 
-# in the hardware:
+# In case of misaligned data memory access:
 # mscratch stores the instruction
-# csr 0x7f0 stores the addr
-# csr 0x7f1 stores for loads: target register
+# csr mtval stores the addr
+# csr 0x7f0 stores for loads: target register
 #                  for stores: data to be written
 
 .global mtvec_handler
@@ -55,7 +55,7 @@ load_misaligned:
 
 lw_misalignment:
     csrr t5, mscratch
-    csrr t3, 0x7f0              # stores addr
+    csrr t3, mtval              # stores addr
     andi t4, t3, 0x00000003     # stores offset
     slli t4, t4, 0x3            # stores offset in bits
     andi t3, t3, 0xfffffffc     # stores proper address of lower word
@@ -67,7 +67,7 @@ lw_misalignment:
     srl t0, t3, t4              # shifts lower word right by offset
     sll t1, t6, t2              # shifts upper word left by 32-offset
     add t0, t0, t1              # final result
-    csrr t1, 0x7f1
+    csrr t1, 0x7f0
     sll t1, t1, 0x2
     add t1, t1, sp
     sw t0, 0(t1)
@@ -75,7 +75,7 @@ lw_misalignment:
 
 lh_misalignment:
     csrr t5, mscratch
-    csrr t3, 0x7f0              # stores addr
+    csrr t3, mtval              # stores addr
     andi t4, t3, 0x00000003     # stores offset
     li t2, 0x1
     beq t4, t2, lh_offset1
@@ -106,7 +106,7 @@ lh_offset3:
     srai t3, t3, 16
     j lh_misalignment_epilogue
 lh_misalignment_epilogue:
-    csrr t1, 0x7f1
+    csrr t1, 0x7f0
     sll t1, t1, 0x2
     add t1, t1, sp
     sw t3, 0(t1)
@@ -114,7 +114,7 @@ lh_misalignment_epilogue:
 
 lhu_misalignment:
     csrr t5, mscratch
-    csrr t3, 0x7f0              # stores addr
+    csrr t3, mtval              # stores addr
     andi t4, t3, 0x00000003     # stores offset
     li t2, 0x1
     beq t4, t2, lhu_offset1
@@ -145,7 +145,7 @@ lhu_offset3:
     srli t3, t3, 16
     j lh_misalignment_epilogue
 lhu_misalignment_epilogue:
-    csrr t1, 0x7f1
+    csrr t1, 0x7f0
     sll t1, t1, 0x2
     add t1, t1, sp
     sw t3, 0(t1)
@@ -163,7 +163,7 @@ store_misaligned:
 
 sh_misalignment:
     csrr t5, mscratch
-    csrr t3, 0x7f0              # stores addr
+    csrr t3, mtval              # stores addr
     andi t4, t3, 0x00000003     # stores offset
     li t2, 0x1
     beq t4, t2, sh_offset1
@@ -171,7 +171,7 @@ sh_misalignment:
     beq t4, t2, sh_offset3
 sh_offset1:
     andi t3, t3, 0xfffffffc     # address of the word
-    csrr t4, 0x7f1              # halfword to be written
+    csrr t4, 0x7f0              # halfword to be written
     slli t4, t4, 8
     lw t5, 0(t3)
     li t6, 0xff0000ff
@@ -183,7 +183,7 @@ sh_offset1:
     j finalize
 sh_offset3:
     andi t3, t3, 0xfffffffc     # address of the lower word
-    csrr t4, 0x7f1              # halfword to be written
+    csrr t4, 0x7f0              # halfword to be written
     andi t5, t4, 0x0ff          # lower byte -> t5
     srli t6, t4, 8
     andi t6, t6, 0x0ff          # upper byte -> t6
@@ -192,8 +192,8 @@ sh_offset3:
     j finalize
 
 sw_misalignment:
-    csrr t3, 0x7f0          # addr -> t3
-    csrr t6, 0x7f1          # word -> t6
+    csrr t3, mtval          # addr -> t3
+    csrr t6, 0x7f0          # word -> t6
     li t2, 0x0ff
     and t2, t2, t6         # byte 0 -> t2
     sb t2, 0(t3)

--- a/ut/v-front/Makefrag
+++ b/ut/v-front/Makefrag
@@ -6,4 +6,5 @@
 v-front_tests = \
     bypass \
     csr_hazard \
-    csr_permissions
+    csr_permissions \
+    illegal_instr

--- a/ut/v-front/Makefrag
+++ b/ut/v-front/Makefrag
@@ -1,10 +1,11 @@
 # Makefrag for V-FRONT specific tests
 # Created:      2025-05-31
-# Modified:     2026-07-10
+# Modified:     2026-07-11
 # Author:       Kagan Dikmen
 
 v-front_tests = \
     bypass \
     csr_hazard \
     csr_permissions \
-    illegal_instr
+    illegal_instr \
+    illegal_instr_addr

--- a/ut/v-front/Makefrag
+++ b/ut/v-front/Makefrag
@@ -1,8 +1,9 @@
 # Makefrag for V-FRONT specific tests
 # Created:      2025-05-31
-# Modified:     2025-06-03
+# Modified:     2026-07-10
 # Author:       Kagan Dikmen
 
 v-front_tests = \
     bypass \
-    csr_hazard
+    csr_hazard \
+    csr_permissions

--- a/ut/v-front/csr_permissions.S
+++ b/ut/v-front/csr_permissions.S
@@ -1,0 +1,37 @@
+// V-FRONT Test Suite - Test for CSR permissions
+// Created:     2026-07-10
+// Modified:    2026-07-10
+// Author:      Kagan Dikmen
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32M
+RVTEST_CODE_BEGIN
+
+    li TESTNUM, 1
+    li x1, 4
+    csrr x1, mhartid
+    bne x1, x0, fail
+
+    li TESTNUM, 2
+    li x1, 4
+    csrw mhartid, x1
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+
+    TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+    .data
+RVTEST_DATA_BEGIN
+
+    TEST_DATA
+
+RVTEST_DATA_END

--- a/ut/v-front/illegal_instr.S
+++ b/ut/v-front/illegal_instr.S
@@ -1,0 +1,26 @@
+// V-FRONT Test Suite - Test for illegal instructions
+// Created:     2026-07-10
+// Modified:    2026-07-10
+// Author:      Kagan Dikmen
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32M
+RVTEST_CODE_BEGIN
+
+    li TESTNUM, 1
+    li x1, 0x4
+    add x1, x1, x1      # Corrupt this instruction in illegal_instr.mem and then simulate
+    ebreak
+
+    TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+    .data
+RVTEST_DATA_BEGIN
+
+    TEST_DATA
+
+RVTEST_DATA_END

--- a/ut/v-front/illegal_instr_addr.S
+++ b/ut/v-front/illegal_instr_addr.S
@@ -1,0 +1,32 @@
+// V-FRONT Test Suite - Test for illegal instruction address
+// Created:     2026-07-11
+// Modified:    2026-07-11
+// Author:      Kagan Dikmen
+
+#include "riscv_test.h"
+#include "test_macros.h"
+
+RVTEST_RV32M
+RVTEST_CODE_BEGIN
+
+    li TESTNUM, 1
+    li x1, 0x4
+    j test_target       # Corrupt this instruction in illegal_instr_addr.mem and then simulate
+    ebreak
+
+    TEST_PASSFAIL
+
+RVTEST_CODE_END
+
+test_target:
+
+    li x31, 0xFF
+    add x31, x31, x0
+    unimp
+
+    .data
+RVTEST_DATA_BEGIN
+
+    TEST_DATA
+
+RVTEST_DATA_END


### PR DESCRIPTION
This pull request removes the BRAM from the CSR unit and only leaves a selected subset of CSRs in the unit. It also handles read/write permissions to these CSRs.e CSRs.

This pull request also ensures that mcause values raised in the case of exception fit to the ISA specification.

Lastly, this pull request extends the exception logic of the processor in general. It adds:

- illegal instruction (including illegal CSR instruction)
- illegal instruction address (after a taken branch or jump)

into the set of exceptions the hardware can raise.

This pull request resolves #23, resolves #28. It also addresses #25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced pipeline and trap handling for illegal instructions, illegal CSR accesses, and misaligned instruction targets, including correct exception/CSR behavior and NOP insertion.
* **Documentation**
  * Added CSR unit documentation and refreshed README architectural details, expanded the exception list, and updated known limitations.
* **Tests**
  * Added V-FRONT coverage for CSR permissions, illegal instructions, and illegal instruction addresses.
* **Chores**
  * Updated automated test selection to omit newly excluded tests from the “passing” set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->